### PR TITLE
Add java module information

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 	</dependency>
 </dependencies>
 ```
+Require the java module with: `require com.github.kmehrunes.javalinjwt;`
 
 ## Features
 - Helper functions for Javalin Context to make working with JWTs easier, includes: extracting tokens from authorization headers, adding/getting tokens to/from cookies, and adding decoded JWT objects to contexts for future handlers to use

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.15.0</version>
+            <version>3.18.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.kmehrunes</groupId>
     <artifactId>javalin-jwt</artifactId>
-    <version>0.3</version>
+    <version>0.4</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,14 @@
             <artifactId>java-jwt</artifactId>
             <version>3.18.1</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>22.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,4 +64,45 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <!-- compile everything to ensure module-info contains right entries -->
+                            <!-- required when JAVA_HOME is JDK 8 or below -->
+                            <jdkToolchain>
+                                <version>9</version>
+                            </jdkToolchain>
+                            <release>9</release>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <!-- recompile everything for target VM except the module-info.java -->
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+                <!-- defaults for compile and testCompile -->
+                <configuration>
+                    <!-- jdkToolchain required when JAVA_HOME is JDK 9 or above -->
+                    <jdkToolchain>
+                        <version>[1.8,9)</version>
+                    </jdkToolchain>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module com.github.kmehrunes.javalinjwt {
+    exports javalinjwt; // will not include the examples package
+
+    requires io.javalin;
+    requires com.auth0.jwt;
+    // The org.jetbrains.annotations package only includes annotations for code analysis tools.
+    // static will prevent the runtime from checking if the package is in the class path.
+    requires static org.jetbrains.annotations;
+}


### PR DESCRIPTION
Hi,
I am currently starting to use Javalin with modules enabled and saw that this project doesn't have a module declaration. I like this project and would love to see it with a module declaration.
With this PR I offer you my changes to add module support to this package. It doesn't change the usage it only enables the usage of it in a module system without the need of the module-info auto generation tool.
IMO it would be nice to have it and enable future java features that might profit from it.