### PR TITLE
Fix JitPack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+    - openjdk9


### PR DESCRIPTION
Hi sorry for bothering you. I haven't worked with JitPack before, so that I totally missed that they use Java 8 as default version to build the artifacts. The changes introduced in #5 require a Java version >= 9 so that the build of the last version (v0.4) failed.
I think this should fix the issue.
I tested the commit 4cd61fc against JitPack https://jitpack.io/com/github/hamburghammer/javalin-jwt/-4cd61fcfdc-1/build.log and it builds.

I am so sorry for missing this.
Can you re release the last version with this patch? 